### PR TITLE
Add basis evaluations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.6-DEV"
 
 [deps]
 ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"
+ACE1x = "5cc4c08c-8782-4a30-af6d-550b302e9707"
 ACEbase = "14bae519-eb20-449c-a949-9c58ed33163e"
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 CellListMap = "69e1c6dd-3888-40e6-b3c8-31ac5f578864"
@@ -27,6 +28,7 @@ ACE_Molly_ext = "Molly"
 
 [compat]
 ACE1 = "0.11.5"
+ACE1x = "0.1.8"
 ACEbase = "0.4.3"
 AtomsBase = "0.3"
 CellListMap = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ACEmd"
 uuid = "69e0c927-b120-467d-b2b3-5b6842148cf4"
 authors = ["Teemu Järvinen <teemu.j.jarvinen@gmail.com> and contributors"]
-version = "0.1.5"
+version = "0.1.6-DEV"
 
 [deps]
 ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"
+ACE1x = "5cc4c08c-8782-4a30-af6d-550b302e9707"
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ExtXYZ = "352459e4-ddd7-4360-8937-99dcb397b478"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,7 @@
 using BenchmarkTools
 using ACEmd
 using ACE1
+using ACE1x
 using ExtXYZ
 using AtomsBase
 
@@ -17,6 +18,15 @@ data_julip_huge = read_extxyz(fname_xyz_huge)[end]
 data = FastSystem(ExtXYZ.Atoms(read_frame(fname_xyz)))
 data_huge = FastSystem(ExtXYZ.Atoms(read_frame(fname_xyz_huge)))
 
+model = acemodel(
+    elements = [:Ti, :Al],
+	order = 3,
+	totaldegree = 6,
+	rcut = 5.5,
+	Eref = [:Ti => -1586.0195, :Al => -105.5954]
+)
+
+basis = model.basis
 
 
 SUITE["JuLIP"] = BenchmarkGroup([],
@@ -32,18 +42,24 @@ SUITE["AtomsBase"] = BenchmarkGroup([],
 
 SUITE["JuLIP"]["energy"]["big"] = @benchmarkable ACE1.energy($pot_julip, $data_julip)
 SUITE["JuLIP"]["energy"]["huge"] = @benchmarkable ACE1.energy($pot_julip, $data_julip_huge)
+SUITE["JuLIP"]["energy"]["basis"] = @benchmarkable ACE1.energy($(basis.BB[2]), $data_julip)
 SUITE["AtomsBase"]["energy"]["big"] = @benchmarkable ace_energy($pot, $data)
 SUITE["AtomsBase"]["energy"]["huge"] = @benchmarkable ace_energy($pot, $data_huge)
+SUITE["AtomsBase"]["energy"]["basis"] = @benchmarkable ace_energy($(basis.BB[2]), $data)
 
 SUITE["JuLIP"]["forces"]["big"] = @benchmarkable ACE1.forces($pot_julip, $data_julip)
 SUITE["JuLIP"]["forces"]["huge"] = @benchmarkable ACE1.forces($pot_julip, $data_julip_huge)
+SUITE["JuLIP"]["forces"]["basis"] = @benchmarkable ACE1.forces($(basis.BB[2]), $data_julip)
 SUITE["AtomsBase"]["forces"]["big"] = @benchmarkable ace_forces($pot, $data)
 SUITE["AtomsBase"]["forces"]["huge"] = @benchmarkable ace_forces($pot, $data_huge)
+SUITE["AtomsBase"]["forces"]["basis"] = @benchmarkable ace_forces($(basis.BB[2]), $data)
 
 SUITE["JuLIP"]["virial"]["big"] = @benchmarkable ACE1.virial($pot_julip, $data_julip)
 SUITE["JuLIP"]["virial"]["huge"] = @benchmarkable ACE1.virial($pot_julip, $data_julip_huge)
+SUITE["JuLIP"]["virial"]["basis"] = @benchmarkable ACE1.virial($(basis.BB[2]), $data_julip)
 SUITE["AtomsBase"]["virial"]["big"] = @benchmarkable ace_virial($pot, $data)
 SUITE["AtomsBase"]["virial"]["huge"] = @benchmarkable ace_virial($pot, $data_huge)
+SUITE["AtomsBase"]["virial"]["basis"] = @benchmarkable ace_virial($(basis.BB[2]), $data)
 
 
 

--- a/src/ACEmd.jl
+++ b/src/ACEmd.jl
@@ -11,6 +11,7 @@ using ChunkSplitters
 using Folds
 @reexport using Folds: ThreadedEx, SequentialEx, DistributedEx
 using FLoops
+using LinearAlgebra: norm
 using NeighbourLists
 using SparseArrays
 using StaticArrays

--- a/src/ACEmd.jl
+++ b/src/ACEmd.jl
@@ -3,6 +3,7 @@ module ACEmd
 using Reexport
 
 import ACE1
+import ACE1x
 using ACEbase
 @reexport using AtomsBase
 using CellListMap

--- a/src/api.jl
+++ b/src/api.jl
@@ -334,3 +334,55 @@ function ace_forces(
     end
     return f
 end
+
+
+function ace_forces(
+    pair_basis::ACE1.PolyPairBasis,
+    at;
+    domain=1:length(at),
+    executor=ThreadedEx(),
+    ntasks=Threads.nthreads(),
+    cutoff_unit=default_length,
+    kwargs...
+)   
+    nlist = neighborlist(at, get_cutoff(pair_basis; cutoff_unit=cutoff_unit) )
+    pair_data = [ (i, j, R)  for (i,j,R) in pairs(nlist) if i in domain ]
+    F = Folds.sum( collect(chunks(pair_data, ntasks)), executor ) do (d, _)
+        ace_forces(pair_basis, at, pair_data, d)
+    end
+    return [ Vector(f) for f in eachrow(F)]
+end
+
+
+function ace_forces(
+    pair_basis::ACE1.PolyPairBasis,
+    at,
+    pair_data,
+    domain
+)
+    f = zeros(SVector{3, Float64}, length(pair_basis), length(at))
+    tmp = ACE1.alloc_temp_d(pair_basis)
+    #@info "chuck is" pair_domain
+    for I in domain
+        # Pairpotential evaluator from JuLIP.
+        # This is temporary implementation and will be changed in the future
+        i, j, R = pair_data[I]
+        r = norm(R)
+        Zi = _atomic_number(at, i)
+        Zj = _atomic_number(at, j)
+        Ii = ACE1.z2i(pair_basis, Zi)
+        Ij = ACE1.z2i(pair_basis, Zj)
+        dJ = tmp.dJ[Ii, Ij]
+        ACE1.evaluate_d!(tmp.J[Ii, Ij], dJ, tmp.tmpd_J[Ii, Ij], pair_basis.J[Ii, Ij], r, Zi, Zj)
+        idx0 = pair_basis.bidx0[Ii, Ij] 
+        r_tmp = R/(2r)
+        for n = 1:length(pair_basis.J[Ii, Ij])
+            f[idx0 + n, i] +=  dJ[n] * r_tmp
+        end
+        for n = 1:length(pair_basis.J[Ii, Ij])
+            f[idx0 + n, j] -= dJ[n] * r_tmp
+        end
+    end
+    return f
+end
+

--- a/src/backend.jl
+++ b/src/backend.jl
@@ -3,19 +3,37 @@
     return ACE1.evaluate!(tmp, calc, R, species, species0)
 end
 
+@inline function ace_evaluate!(B, tmp, calc, R::AbstractVector, species::AbstractVector, species0 )
+    ACE1.evaluate!(B, tmp, calc, R, species, species0)
+    return B
+end
+
 function ace_evaluate(calc, R::AbstractVector, species::AbstractVector, species0)
     tmp = ACE1.alloc_temp(calc, length(R))
     return ace_evaluate!(tmp, calc, R, species, species0)
 end
 
-
-@inline function ace_evaluate_d!(out, tmp, calc, R::AbstractVector, species::AbstractVector, species0)
-    e = ACE1.evaluate_d!(out, tmp, calc, R, species::AbstractVector, species0 )
-    return e, tmp
+function ace_evaluate(calc::ACE1.IPBasis, R::AbstractVector, species::AbstractVector, species0)
+    B = ACE1.alloc_B(calc)
+    tmp = ACE1.alloc_temp(calc, length(R))
+    return ace_evaluate!(B, tmp, calc, R, species, species0)
 end
 
+
+@inline function ace_evaluate_d!(out, tmp, calc, R::AbstractVector, species::AbstractVector, species0)
+    e = ACE1.evaluate_d!(out, tmp, calc, R, species, species0 )
+    return e, tmp
+end
 
 function ace_evaluate_d(calc, R::AbstractVector, species::AbstractVector, species0)
     tmp = ACE1.alloc_temp_d(calc, length(R))
     return ace_evaluate_d!(tmp.dV, tmp, calc, R::AbstractVector, species::AbstractVector, species0)
+end
+
+
+function ace_evaluate_d(basis::ACE1.IPBasis, R::AbstractVector, species::AbstractVector, species0)
+    dB  = ACE1.alloc_dB(basis, length(R))
+    tmp = ACE1.alloc_temp_d(basis, length(R))
+    ace_evaluate_d!(dB, tmp, basis, R, species, species0)
+    return dB
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"
+ACE1x = "5cc4c08c-8782-4a30-af6d-550b302e9707"
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 ExtXYZ = "352459e4-ddd7-4360-8937-99dcb397b478"
 Molly = "aa0f7f06-fcc0-5ec4-a7f3-a573f33f9c4c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ACEmd
 using ACE1
+using ACE1x
 using AtomsBase
 using ExtXYZ
 using Molly
@@ -22,6 +23,17 @@ const u_length = ACEmd.default_length
     @test ace_energy(pot, data) ≈ ACE1.energy(pot_old, data) * u_energy
     @test all( ace_forces(pot, data) .≈ ACE1.forces(pot_old, data) * (u_energy / u_length) )
     @test ace_virial(pot, data) ≈ ACE1.virial(pot_old, data) * (u_energy * u_length)
+
+    @testset "Basis evaluations" begin
+        basis = ACE1x.ace_basis(
+            elements = [:Ti, :Al],
+            order = 3,
+            totaldegree = 6,
+            rcut = 5.5,
+        )
+        @test all( ace_energy(basis.BB[2], data) .≈ ACE1.energy(basis.BB[2], data)  )
+
+    end
 end
 
 
@@ -36,6 +48,8 @@ end
     F = ace_forces(pot, ab_data)
     @test typeof(F) <: Array
     @test ace_energy(pot, ab_data) ≈ sum( ace_atom_energies(pot, ab_data) )
+
+    @test all( ace_energy(pot[3].pibasis, ab_data) .≈ ace_energy(pot[3].pibasis, julip_data)  )
 end
 
 @testset "Units" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,14 @@ const u_length = ACEmd.default_length
             rcut = 5.5,
         )
         @test all( ace_energy(basis.BB[2], data) .≈ ACE1.energy(basis.BB[2], data)  )
+        @test (all∘map)( ace_forces(basis.BB[2], data), ACE1.forces(basis.BB[2], data)) do a,b
+            all( a .≈ b  )
+        end
+
+        @test all( ace_energy(basis.BB[1], data) .≈ ACE1.energy(basis.BB[1], data)  )
+        @test (all∘map)( ace_forces(basis.BB[1], data), ACE1.forces(basis.BB[1], data)) do a,b
+            all( a .≈ b  )
+        end
 
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ const u_length = ACEmd.default_length
             all( a .≈ b  )
         end
 
-        # pair potential bassis
+        # pair potential basis
         @test all( ace_energy(basis.BB[1], data) .≈ ACE1.energy(basis.BB[1], data)  )
         @test (all∘map)( ace_forces(basis.BB[1], data), ACE1.forces(basis.BB[1], data)) do a,b
             all( a .≈ b  )
@@ -68,6 +68,35 @@ end
     @test ace_energy(pot, ab_data) ≈ sum( ace_atom_energies(pot, ab_data) )
 
     @test all( ace_energy(pot[3].pibasis, ab_data) .≈ ace_energy(pot[3].pibasis, julip_data)  )
+
+    @testset "Basis evaluations" begin
+        model = acemodel(
+            elements = [:Ti, :Al],
+			order = 3,
+			totaldegree = 6,
+			rcut = 5.5,
+			Eref = [:Ti => -1586.0195, :Al => -105.5954]
+        )
+        basis = model.basis
+        # ACE basis
+        @test all( ace_energy(basis.BB[2], ab_data) .≈ ace_energy(basis.BB[2], julip_data)  )
+        @test (all∘map)( ace_forces(basis.BB[2], ab_data), ace_forces(basis.BB[2], julip_data) ) do a,b
+            all( a .≈ b  )
+        end
+        @test (all∘map)( ace_virial(basis.BB[2], ab_data), ace_virial(basis.BB[2], julip_data) ) do a,b
+            all( a .≈ b  )
+        end
+
+        # pair potential basis
+        @test all( ace_energy(basis.BB[1], ab_data) .≈ ace_energy(basis.BB[1], julip_data)  )
+        @test (all∘map)( ace_forces(basis.BB[1], ab_data), ace_forces(basis.BB[1], julip_data) ) do a,b
+            all( a .≈ b  )
+        end
+        @test (all∘map)( ace_virial(basis.BB[1], ab_data), ace_virial(basis.BB[1], julip_data) ) do a,b
+            all( a .≈ b  )
+        end
+
+    end
 end
 
 @testset "Units" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,19 +25,29 @@ const u_length = ACEmd.default_length
     @test ace_virial(pot, data) ≈ ACE1.virial(pot_old, data) * (u_energy * u_length)
 
     @testset "Basis evaluations" begin
-        basis = ACE1x.ace_basis(
+        model = acemodel(
             elements = [:Ti, :Al],
-            order = 3,
-            totaldegree = 6,
-            rcut = 5.5,
+			order = 3,
+			totaldegree = 6,
+			rcut = 5.5,
+			Eref = [:Ti => -1586.0195, :Al => -105.5954]
         )
+        basis = model.basis
+        # ACE basis
         @test all( ace_energy(basis.BB[2], data) .≈ ACE1.energy(basis.BB[2], data)  )
         @test (all∘map)( ace_forces(basis.BB[2], data), ACE1.forces(basis.BB[2], data)) do a,b
             all( a .≈ b  )
         end
+        @test (all∘map)( ace_virial(basis.BB[2], data), ACE1.virial(basis.BB[2], data)) do a,b
+            all( a .≈ b  )
+        end
 
+        # pair potential bassis
         @test all( ace_energy(basis.BB[1], data) .≈ ACE1.energy(basis.BB[1], data)  )
         @test (all∘map)( ace_forces(basis.BB[1], data), ACE1.forces(basis.BB[1], data)) do a,b
+            all( a .≈ b  )
+        end
+        @test (all∘map)( ace_virial(basis.BB[1], data), ACE1.virial(basis.BB[1], data)) do a,b
             all( a .≈ b  )
         end
 


### PR DESCRIPTION
Add support for using basis as an input. With this ACEmd can be used to train models once support is added to ACEfit.