### PR TITLE
Update ASE calculator helper functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ACEmd"
 uuid = "69e0c927-b120-467d-b2b3-5b6842148cf4"
 authors = ["Teemu Järvinen <teemu.j.jarvinen@gmail.com> and contributors"]
-version = "0.1.10"
+version = "0.1.11"
 
 
 [deps]


### PR DESCRIPTION
The problem with ASE calculator has been python GIL that prevents GC from anything else than main thread. Julia can do GC from all threads. This leads to issues when using juliacall from python.

To solve the issue the calculations are now performed on another process, which is free to use GC as it wishes. Thus effectively fixing the GIL issue. 